### PR TITLE
Enable Source Attribute on Submission #Create and #Show

### DIFF
--- a/app/controllers/extsubmissions/new.js
+++ b/app/controllers/extsubmissions/new.js
@@ -31,6 +31,7 @@ export default Ember.ObjectController.extend({
     submission.set('candidateEmail', this.get('candidateEmail'));
     submission.set('level', this.get('selectedLevel'));
     submission.set('language', this.get('selectedLanguage'));
+    submission.set('source', 'External Submission');
     return submission.save();
   },
 

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.ObjectController.extend({
-  breadCrumb: 'New Submission',
+    breadCrumb: 'New Submission',
     candidateName: null,
     candidateEmail: null,
     selectedLanguage: null,
     selectedLevel: null,
+    sources: ['LinkedIn', 'StackOverflow', 'Whitetruffle', 'Switch', 'Recuiter / Agency', 'Referral', 'Other'],
 
     isFormIncomplete: Ember.computed.or('isCandidateIncomplete', 'isSubmissionIncomplete'),
 
@@ -31,6 +32,7 @@ export default Ember.ObjectController.extend({
         submission.set('candidateEmail', this.get('candidateEmail'));
         submission.set('level', this.get('selectedLevel'));
         submission.set('language', this.get('selectedLanguage'));
+        submission.set('source', this.get('selectedSource'));
         return submission.save();
     },
 

--- a/app/models/extsubmission.js
+++ b/app/models/extsubmission.js
@@ -12,6 +12,7 @@ export default DS.Model.extend({
   createdAt: DS.attr(),
   updatedAt: DS.attr(),
   averageScore: DS.attr(),
+  source: DS.attr(),
 
   level: DS.belongsTo('level'),
   language: DS.belongsTo('language'),

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -12,6 +12,7 @@ export default DS.Model.extend({
     createdAt: DS.attr(),
     updatedAt: DS.attr(),
     averageScore: DS.attr(),
+    source: DS.attr(),
 
     level: DS.belongsTo('level'),
     language: DS.belongsTo('language'),
@@ -32,6 +33,7 @@ export default DS.Model.extend({
     createdAtDisplay: function() {
         return moment(this.get('createdAt')).format('l LT');
     }.property('createdAt'),
+
     updatedAtDisplay: function() {
         return moment(this.get('updatedAt')).format('l LT');
     }.property('updatedAt')

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
         return Ember.Object.create({
             submission: this.store.createRecord('submission'),
             languages: this.store.find('language'),
-            levels: this.store.find('level')
+            levels: this.store.find('level'),
         });
     },
 

--- a/app/templates/assessment-edit.hbs
+++ b/app/templates/assessment-edit.hbs
@@ -42,6 +42,18 @@
             <p class="form-control-static">{{submission.emailText}}</p>
           </div>
         </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Source of Referral</label>
+          <div class="col-sm-10">
+            {{#if submission.source}}
+            <p class="form-control-static">{{submission.source}}</p>
+            {{else}}
+            <p class="form-control-static">N/A (source was not provided)</p>
+            {{/if}}
+          </div>
+        </div> 
+
       </fieldset>
     </form>
 

--- a/app/templates/submission/index.hbs
+++ b/app/templates/submission/index.hbs
@@ -30,6 +30,13 @@
           </div>
         </div>
 
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Source of Referral</label>
+          <div class="col-sm-10">
+            <p class="form-control-static">{{source}}</p>
+          </div>
+        </div>        
+
         {{#if hasPublishedAssessments}}
         <div class="form-group">
           <label class="col-sm-2 control-label">Consensus</label>

--- a/app/templates/submission/index.hbs
+++ b/app/templates/submission/index.hbs
@@ -33,7 +33,11 @@
         <div class="form-group">
           <label class="col-sm-2 control-label">Source of Referral</label>
           <div class="col-sm-10">
+            {{#if source}}
             <p class="form-control-static">{{source}}</p>
+            {{else}}
+            <p class="form-control-static">N/A (source was not provided)</p>
+            {{/if}}
           </div>
         </div>        
 

--- a/app/templates/submissions/new.hbs
+++ b/app/templates/submissions/new.hbs
@@ -45,6 +45,17 @@
           </div>
 
           <div class="form-group">
+            <label class="col-sm-2 control-label">Source of Referral</label>
+            <div class="col-sm-4">
+              {{view 'select' 
+                  content=sources
+                  selectionBinding="selectedSource"
+                  prompt="Select a source"
+                  class='form-control'}}
+            </div>
+          </div>          
+
+          <div class="form-group">
             <label class="col-sm-2 control-label">Email Text</label>
             <div class="col-sm-6">
               <p>Copy and paste the email text or any instructions given by the candidate.</p>


### PR DESCRIPTION
Modifies the Submission and Extsubmission models/templates/routes and controllers to accommodate a new 'source' attribute. Also displays a Submissions source on its #show page as well as new/edit assessment pages.