### PR TITLE
Implement Testing in Ember App

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -32,6 +32,13 @@ module.exports = function(environment) {
     ENV.NEW_SESSION_URL = 'http://localhost:3000/sessions/new';
   }
 
+  if (environment === 'test') {
+    ENV.baseURL = '/'; // Testem prefers this...
+    ENV.SERVER_HOST = 'http://localhost:3000';
+    ENV.APP_HOST = 'http://localhost:4200';
+    ENV.NEW_SESSION_URL = 'http://localhost:3000/sessions/new';    
+  }
+
   if (environment === 'production') {
       ENV.SERVER_HOST = 'https://codetestbotserver.herokuapp.com';
       ENV.APP_HOST = 'https://codetestbot.herokuapp.com';

--- a/tests/acceptance/load-thanks-page-test.js
+++ b/tests/acceptance/load-thanks-page-test.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+
+module('Acceptance: Load Thanks Page', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /thanks', function() {
+  visit('/thanks');
+
+  andThen(function() {
+    equal(currentPath(), 'thanks');
+  });
+});
+
+test('loads thanks element', function() {
+  visit('/thanks');
+
+  andThen(function() {
+    equal(find('.thank-you-img-container').length, 1);
+  });
+});

--- a/tests/acceptance/secured-test.js
+++ b/tests/acceptance/secured-test.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+
+module('Acceptance: Secured', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /', function() {
+  visit('/');
+
+  andThen(function() {
+    equal(currentPath(), 'auth/login');
+  });
+});

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import Application from 'code-test-bot-app/app';
+import Router from 'code-test-bot-app/router';
+
+export default function startApp(attrs) {
+  var App;
+
+  var attributes = Ember.merge({
+    // useful Test defaults
+    rootElement: '#ember-testing',
+    LOG_ACTIVE_GENERATION: false,
+    LOG_VIEW_LOOKUPS: false
+  }, attrs); // but you can override;
+
+  Router.reopen({
+    location: 'none'
+  });
+
+  Ember.run(function() {
+    App = Application.create(attributes);
+    App.setupForTesting();
+    App.injectTestHelpers();
+  });
+
+  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
+
+  return App;
+}


### PR DESCRIPTION
Changed a bit of the configuration to enable us to write basic tests. Now we can build on these tests to build on the suite and bring TDD back to the App.